### PR TITLE
fix lua array behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ var luaStyleArray = convertToLuaStyle(['this is', 'a lua-style array']);
 console.log(luaStyleArray[1]);
 // this is
 console.log(luaStyleArray[0]);
-// null
+// undefined
 ```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = convertToLuaStyle;
+const LuaArray = require('./structures/LuaArray');
 
 /**
  * Converts an array to a Lua-style array that starts at one
@@ -6,15 +6,13 @@ module.exports = convertToLuaStyle;
  * @returns {Array} The Lua-style array
  */
 function convertToLuaStyle(theArray) {
-    if (theArray instanceof Array) {
-        if (theArray.length > 0) {
-            if (theArray[0] == null) {
-                console.warn('lua-style-arrays : this array may already be lua-style?');
-            }
-        }
-        theArray.unshift(null);
-        return theArray;
+    if (theArray instanceof LuaArray) {
+        throw new Error('The provided array is already a Lua-styled array.');
+    } else if (Array.isArray(theArray)) {
+        return new LuaArray(theArray);
     } else {
-        throw new Error('trying to convert non-array into a Lua-style array');
+        throw new Error('Trying to convert non-array into a Lua-style array.');
     }
 }
+
+module.exports = convertToLuaStyle;

--- a/structures/LuaArray.js
+++ b/structures/LuaArray.js
@@ -1,0 +1,19 @@
+class LuaArray extends Array {
+    // Overwrite MyArray species to the parent Array constructor
+    static get [Symbol.species]() { return Array; }
+
+    constructor(array) {
+        array.unshift(undefined);
+        super(...array);
+    }
+
+    unshift(element) {
+        return this.splice(1, 0, element);
+    }
+
+    shift(element) {
+        return this.splice(1, 1)[0];
+    }
+}
+
+module.exports = LuaArray;

--- a/test.js
+++ b/test.js
@@ -9,11 +9,20 @@ function luaStyleArrayError() {
 
 describe('Lua-style arrays', () => {
     it('should be Lua-style', () => {
-        var testArray = convertToLuaStyle(['this', 'is', 'a', 'test']);
-        expect(testArray[0]).to.equal(null);
+        let testArray = convertToLuaStyle(['this', 'is', 'a', 'test']);
+        expect(testArray[0]).to.equal(undefined);
         expect(testArray[1]).to.equal('this');
+
+        testArray.unshift('extraneous');
+        expect(testArray[0]).to.equal(undefined);
+        expect(testArray[1]).to.equal('extraneous');
+
+        let shifted = testArray.shift();
+        expect(testArray[0]).to.equal(undefined);
+        expect(testArray[1]).to.equal('this');
+        expect(shifted).to.equal('extraneous');
     });
     it('should error when I pass a non-array to the function', () => {
-        assert.throws(luaStyleArrayError, Error, 'trying to convert non-array into a Lua-style array');
+        assert.throws(luaStyleArrayError, Error, 'Trying to convert non-array into a Lua-style array.');
     });
 });


### PR DESCRIPTION
### lua-style-arrays Pull Request

#### Describe what your pull request does

This PR fixes the behaviour of lua-styled arrays by doing the following:
1. Creating a new `LuaArray` class which extends array for prototype overrides and instance checking
2. Changing the index 0 of an array to `undefined` instead of `null`, which is what is expected when trying to access an index which does not exist
3. Override `shift` and `unshift` to take in account the fact that the array is 1-indexed
4. Update test.js to test for the above changes

#### Why should it be accepted?

Because previously, this module only half-implemented lua-styled arrays.

#### Screenshots/animated GIFs

https://stop-it.get-some.help/534945.gif

#### I have
* [x] made sure there are no pull requests that add this functionality.
* [x] read and followed the [contribution guidelines](https://github.com/LewisTehMinerz/lua-style-arrays/blob/master/CONTRIBUTING.md).
* [x] read and followed the [Code of Conduct](https://github.com/LewisTehMinerz/lua-style-arrays/blob/master/CODE_OF_CONDUCT.md).
