### PR TITLE
better toString solution

### DIFF
--- a/structures/LuaArray.js
+++ b/structures/LuaArray.js
@@ -22,7 +22,7 @@ class LuaArray extends Array {
     }
 
     toString() {
-        return this.toString().substring(1);
+        return this.slice(1).toString();
     }
 
     inspect() {


### PR DESCRIPTION
should slice instead of substring

### lua-style-arrays Pull Request

#### Describe what your pull request does

slices instead of substrings

#### Why should it be accepted?

instead of modifying the result, you should return the result of the modified array

#### Screenshots/animated GIFs

https://stupid-cat.needs-to-s.top/100374.gif

#### I have
* [x] made sure there are no pull requests that add this functionality.
* [x] read and followed the [contribution guidelines](https://github.com/LewisTehMinerz/lua-style-arrays/blob/master/CONTRIBUTING.md).
* [x] read and followed the [Code of Conduct](https://github.com/LewisTehMinerz/lua-style-arrays/blob/master/CODE_OF_CONDUCT.md).
